### PR TITLE
fix interference with other draggable views

### DIFF
--- a/dragsortadapter/src/main/java/com/makeramen/dragsortadapter/DragSortAdapter.java
+++ b/dragsortadapter/src/main/java/com/makeramen/dragsortadapter/DragSortAdapter.java
@@ -96,6 +96,7 @@ public abstract class DragSortAdapter<VH extends DragSortAdapter.ViewHolder>
   }
 
   @Override public boolean onDrag(View v, DragEvent event) {
+    if(!(event.getLocalState() instanceof DragInfo)) return false;
     if (v == recyclerViewRef.get()) {
       final RecyclerView recyclerView = (RecyclerView) v;
       final DragInfo dragInfo = (DragInfo) event.getLocalState();


### PR DESCRIPTION
When I tried to use another draggable view (completely outside the RecyclerView), the DragSortAdapter onDrag method was invoked, beacuse it's registered as a listener for view drag events. Inside this method there is an explicit cast to DragInfo. My View did not implement DragInfo, because it's not connected to DragSortAdapter in any way. And so the app crashed with ClassCastException.