### PR TITLE
Fix race condition with busy wait

### DIFF
--- a/dragsortadapter/src/main/java/com/makeramen/dragsortadapter/DragManager.java
+++ b/dragsortadapter/src/main/java/com/makeramen/dragsortadapter/DragManager.java
@@ -108,12 +108,9 @@ final class DragManager implements View.OnDragListener {
                   // so we try to reschedule the notifyItemChanged until after that
                   recyclerView.post(new Runnable() {
                     @Override public void run() {
-                      recyclerView.getItemAnimator().isRunning(
-                          new RecyclerView.ItemAnimator.ItemAnimatorFinishedListener() {
-                            @Override public void onAnimationsFinished() {
-                              adapter.notifyItemChanged(adapter.getPositionForId(itemId));
-                            }
-                          });
+                      while (recyclerView.getLayoutManager().onRequestChildFocus(recyclerView, null, null, null)) {
+                      }
+                      adapter.notifyItemChanged(getPositionForId(itemId));
                     }
                   });
                 } else {

--- a/dragsortadapter/src/main/java/com/makeramen/dragsortadapter/DragManager.java
+++ b/dragsortadapter/src/main/java/com/makeramen/dragsortadapter/DragManager.java
@@ -108,9 +108,15 @@ final class DragManager implements View.OnDragListener {
                   // so we try to reschedule the notifyItemChanged until after that
                   recyclerView.post(new Runnable() {
                     @Override public void run() {
-                      while (recyclerView.getLayoutManager().onRequestChildFocus(recyclerView, null, null, null)) {
-                      }
-                      adapter.notifyItemChanged(getPositionForId(itemId));
+                      recyclerView.getItemAnimator().isRunning(
+                          new RecyclerView.ItemAnimator.ItemAnimatorFinishedListener() {
+                            @Override public void onAnimationsFinished() {
+                              while (recyclerView.getLayoutManager().onRequestChildFocus(
+                                    recyclerView, null, null, null)) {
+                              }
+                              adapter.notifyItemChanged(adapter.getPositionForId(itemId));
+                            }
+                          });
                     }
                   });
                 } else {

--- a/dragsortadapter/src/main/java/com/makeramen/dragsortadapter/DragManager.java
+++ b/dragsortadapter/src/main/java/com/makeramen/dragsortadapter/DragManager.java
@@ -106,17 +106,15 @@ final class DragManager implements View.OnDragListener {
                 if (vh != null && vh.getAdapterPosition() != position) {
                   // if positions don't match, there's still an outstanding move animation
                   // so we try to reschedule the notifyItemChanged until after that
-                  recyclerView.post(new Runnable() {
-                    @Override public void run() {
-                      recyclerView.getItemAnimator().isRunning(
-                          new RecyclerView.ItemAnimator.ItemAnimatorFinishedListener() {
-                            @Override public void onAnimationsFinished() {
-                              while (recyclerView.getLayoutManager().onRequestChildFocus(
-                                    recyclerView, null, null, null)) {
-                              }
-                              adapter.notifyItemChanged(adapter.getPositionForId(itemId));
-                            }
-                          });
+                  recyclerView.getItemAnimator().isRunning(new RecyclerView.ItemAnimator.ItemAnimatorFinishedListener() {
+                    @Override public void onAnimationsFinished() {
+                      recyclerView.post(new Runnable() {
+                        @Override public void run() {
+                          while (recyclerView.getLayoutManager().onRequestChildFocus(recyclerView, null, null, null)) {
+                          }
+                          adapter.notifyItemChanged(adapter.getPositionForId(itemId));
+                        }
+                      });
                     }
                   });
                 } else {


### PR DESCRIPTION
This fixes a race condition caused by fast dragging and dropping: `adapter.notifyItemChanged` is called while an animation is in progress, causing an `IllegalStateException` to be thrown by the `RecyclerView`. This fix uses `LayoutManager.onRequestChildFocus` to check if an animation is in progress, and if so, it waits until it's not in progress, then continues on to call `notifyItemChanged`. I also have a version of this fix for 1.1.0, if you wanted to make a 1.1.1.
