### PR TITLE
Fix weird scrolling mentioned in #2 and #24 for good.

### DIFF
--- a/dragsortadapter/src/main/java/com/makeramen/dragsortadapter/DragManager.java
+++ b/dragsortadapter/src/main/java/com/makeramen/dragsortadapter/DragManager.java
@@ -68,10 +68,11 @@ final class DragManager implements View.OnDragListener {
                       recyclerView.getChildViewHolder(child).getAdapterPosition();
                   if (adapter.move(fromPosition, toPosition)) {
 
-                    if (fromPosition == 0 || toPosition == 0) {
-                      // fix for weird scrolling when animating first item
-                      recyclerView.scrollToPosition(0);
-                    }
+                      //This is not needed anymore since we fix the wired scrolling bugs in the example adapter.
+//                    if (fromPosition == 0 || toPosition == 0) {
+//                      // fix for weird scrolling when animating first item
+//                      recyclerView.scrollToPosition(0);
+//                    }
 
                     recyclerView.post(new Runnable() {
                       @Override public void run() {

--- a/example/src/main/java/com/makeramen/dragsortadapter/example/ExampleAdapter.java
+++ b/example/src/main/java/com/makeramen/dragsortadapter/example/ExampleAdapter.java
@@ -72,7 +72,16 @@ public class ExampleAdapter extends DragSortAdapter<ExampleAdapter.MainViewHolde
   }
 
   @Override public boolean move(int fromPosition, int toPosition) {
-    data.add(toPosition, data.remove(fromPosition));
+
+    //This if-else block fixes #2 and #24 bugs. This should be put into the base class or users should be warned to avoid wired scrolling.
+    if(fromPosition < toPosition)
+    {
+      data.add(toPosition, data.get(fromPosition));
+      data.remove(fromPosition);
+    }
+    else {
+      data.add(toPosition, data.remove(fromPosition));
+    }
     return true;
   }
 


### PR DESCRIPTION
Maybe we should implement move() method in base class(DragSortAdapter.java) or warn people about the way they move items. Anyway, this should fix the weird scrolling bug when dragging the first item. I think you can see what's going on after reading the changes.
